### PR TITLE
Add debug option.

### DIFF
--- a/placards/__main__.py
+++ b/placards/__main__.py
@@ -25,6 +25,12 @@ async def chrome(chrome_bin, profile_dir):
     ]
     if config.getbool('IGNORE_CERTIFICATE_ERRORS', False):
         args.append('--ignore-certificate-errors')
+    if not config.getbool('DEBUG', False):
+        args.extend([
+        '--noerrdialogs',
+        '--disable-infobars',
+        '--kiosk',
+    ])
     browser = await launch(
         headless=False,
         args=args,

--- a/placards/__main__.py
+++ b/placards/__main__.py
@@ -27,10 +27,10 @@ async def chrome(chrome_bin, profile_dir):
         args.append('--ignore-certificate-errors')
     if not config.getbool('DEBUG', False):
         args.extend([
-        '--noerrdialogs',
-        '--disable-infobars',
-        '--kiosk',
-    ])
+            '--noerrdialogs',
+            '--disable-infobars',
+            '--kiosk',
+        ])
     browser = await launch(
         headless=False,
         args=args,


### PR DESCRIPTION
Add debug config option. When enabled, omit `--kiosk` mode flag (which allows for un-maximizing, right-clicking and developer tools).