### PR TITLE
Parse port from x11vnc output.

### DIFF
--- a/placards/__main__.py
+++ b/placards/__main__.py
@@ -36,7 +36,7 @@ STARTUP = [
 REBOOT = 'reboot now'
 PREFERENCES_PATH = 'Default/Preferences'
 LOADING_HTML = pathjoin(dirname(__file__), 'html/index.html')
-VNC_TIMEOUT=30
+VNC_TIMEOUT = 30
 PORT_PATTERN = re.compile(b'PORT=(\\d+)')
 
 


### PR DESCRIPTION
 - Don't hardcode port, parse it from command output.
 - Set a timeout on `x11vnc` command to prevent it hanging around forever.